### PR TITLE
Updating framework deps in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ In addition, the following iOS dependencies are required:
 - libxml2.dylib
 - libz.dylib
 - UIKit.framework
+- ImageIO.framework
 - Foundation.framework
 - CFNetwork.framework
 - CoreData.framework


### PR DESCRIPTION
Missing ImageIO.framework in the README.
